### PR TITLE
Fix iopipe dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier": "^1.5.2"
   },
   "dependencies": {
-    "iopipe": "^0.8.0",
+    "iopipe": "^1.0.0",
     "performance-node": "^0.2.0"
   },
   "pre-commit": ["test"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,9 +1613,9 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-iopipe@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/iopipe/-/iopipe-0.8.0.tgz#82ea924d54e1c04e8f07aee727e72496c58fb9b5"
+iopipe@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/iopipe/-/iopipe-1.0.1.tgz#1fb9aaa30126dbfc3699273b7a1455907ba3b1e2"
 
 is-arrayish@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
After the release of 1.0, the `^` specification for iopipe means that npm installs both the newer and the older version of iopipe in the dep tree. Updated to `^1.0.0` to allow for newest version of IOpipe to be used, within the 1.0 range.