### PR TITLE
Rename to @iopipe/trace, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Create marks and measures for arbitrary units of time. Measure latency of databa
 
 With [yarn](https://yarnpkg.com) (recommended) in project directory:
 
-`yarn add iopipe-plugin-trace`
+`yarn add @iopipe/trace`
 
 With npm in project directory:
 
-`npm install iopipe-plugin-trace`
+`npm install @iopipe/trace`
 
 Then include the plugin with IOpipe in your serverless function:
 
 ```js
 const iopipeLib = require('iopipe');
-const tracePlugin = require('iopipe-plugin-trace');
+const tracePlugin = require('@iopipe/trace');
 
 const iopipe = iopipeLib({
   token: 'TOKEN_HERE',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "iopipe-plugin-trace",
-  "version": "0.2.0",
+  "name": "@iopipe/trace",
+  "version": "0.3.0",
   "description": "IOpipe plugin for tracing metrics",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -19,7 +19,7 @@ test('Can instantiate the plugin with no options', () => {
   expect(_.isPlainObject(inst.config)).toBe(true);
   expect(inst.timeline instanceof Perf).toBe(true);
   expect(inst.config.autoMeasure).toBe(true);
-  expect(inst.meta.name).toBe('iopipe-plugin-trace');
+  expect(inst.meta.name).toBe('@iopipe/trace');
   expect(inst.meta.version).toBe(pkg.version);
   expect(inst.meta.homepage).toBe(pkg.homepage);
 });


### PR DESCRIPTION
Will run `npm deprecate` when this is merged in.